### PR TITLE
fix: set correct props for Android build

### DIFF
--- a/App_Resources/Android/AndroidManifest.xml
+++ b/App_Resources/Android/AndroidManifest.xml
@@ -32,10 +32,9 @@
 			android:configChanges="keyboardHidden|orientation|screenSize"
 			android:theme="@style/LaunchScreenTheme">
 
-			<meta-data 
-				android:name="SET_THEME_ON_LAUNCH" 
-				android:resource="@style/AppTheme" 
-				tools:replace="android:value"/>
+			<meta-data
+				android:name="SET_THEME_ON_LAUNCH"
+				android:resource="@style/AppTheme"/>
 
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />

--- a/App_Resources/Android/app.gradle
+++ b/App_Resources/Android/app.gradle
@@ -5,28 +5,23 @@
 //	compile 'com.android.support:recyclerview-v7:+'
 //}
 
-project.ext {
-  googlePlayServicesVersion = "11.4.0"
-  firebaseMessagingVersion = "11.4.0"
-  supportVersion = "26.0.0"
-}
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
     generatedDensities = []
-    applicationId = "org.nativescript.angularsde" 
-    
+    applicationId = "org.nativescript.angularsde"
+
     //override supported platforms
     // ndk {
     //       abiFilters.clear()
     //   		abiFilters "armeabi-v7a"
  		// }
-  
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
+
   }
-} 
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}
 
 def settingsGradlePath
 

--- a/App_Resources/Android/before-plugins.gradle
+++ b/App_Resources/Android/before-plugins.gradle
@@ -1,0 +1,12 @@
+// Add your native dependencies here:
+
+// Uncomment to add recyclerview-v7 dependency
+//dependencies {
+//	compile 'com.android.support:recyclerview-v7:+'
+//}
+
+project.ext {
+  googlePlayServicesVersion = "11.4.0"
+  firebaseMessagingVersion = "11.4.0"
+  supportVersion = "28.0.0"
+}


### PR DESCRIPTION
Add before-plugins.gradle file in the App_Resources - it is applied before the `include.gradle` files of all plugins and allows setting specific versions of the play services and support library.
> NOTE: The support library's version must be 28.0.0 - currently NativeScript requires this version and lower ones will not work.